### PR TITLE
Add Photoshop AI plugin design documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# adobe_PS_AI-plugin
+# Adobe Photoshop AI Plugin Concepts
+
+This repository contains conceptual design work for integrating advanced generative or editing AI services into Adobe Photoshop 24.4 via UXP plugins. See [`docs/ai_plugin_design.md`](docs/ai_plugin_design.md) for a detailed architecture proposal and feature breakdown.
+
+## Repository Contents
+- `docs/ai_plugin_design.md` – comprehensive design for a hybrid cloud/on-device AI assistant plugin.
+
+## Getting Started
+While this repo does not include production-ready code, the design document outlines:
+- Recommended development environment setup.
+- Plugin scaffolding and configuration files.
+- Backend service interactions and security considerations.
+
+Use the plan as a reference for building a real plugin that connects Photoshop with AI models such as Qwen, Google "Nano Banana," xAI Grok, or Meta AI services.

--- a/docs/ai_plugin_design.md
+++ b/docs/ai_plugin_design.md
@@ -1,0 +1,184 @@
+# Photoshop 24.4 AI Co-Creation Plugin Design
+
+## 1. Vision & Value Proposition
+Create a UXP-based Photoshop 24.4 plugin that embeds state-of-the-art image generation and editing AI models (e.g., Alibaba Qwen, Google "Nano Banana," xAI Grok, Meta AI) directly into artist workflows. The plugin should:
+- Offer guided prompt crafting, iterative refinement, and contextual editing inside Photoshop.
+- Provide a unified interface for multiple AI backends while abstracting their differences.
+- Maintain user control by blending AI outputs with Photoshop layers and non-destructive editing tools.
+
+## 2. Primary Use Cases
+1. **Text-to-Image Generation** – Generate concept art or mood boards from prompts using models such as Qwen or Meta's Imagine.
+2. **Image-to-Image Variation** – Submit the current canvas or selected layers to Grok's diffusion service to explore styles.
+3. **Smart Inpainting/Outpainting** – Use Google Nano Banana's localized editing capabilities to remove or extend elements.
+4. **Style Transfer & Harmonization** – Apply model-specific filters to match a target reference image.
+5. **Assistive Automation** – Auto-mask subjects, relight scenes, and propose design variations with AI suggestions.
+
+## 3. User Personas
+- **Concept Artist**: Rapid prototyping of scenes and characters.
+- **Marketing Designer**: Variations for campaigns while adhering to brand guidelines.
+- **Retoucher**: Precision edits, background cleanup, and content-aware fill.
+
+## 4. High-Level Architecture
+```
+ ┌─────────────────────────┐       ┌──────────────────────┐
+ │ Photoshop 24.4 (UXP)    │       │ AI Orchestration API │
+ │ ┌─────────────────────┐ │ HTTPS │ ┌──────────────────┐ │
+ │ │ Plugin UI (React)   │◄───────┼─►│ Model Routers   │ │
+ │ │ Photoshop DOM Bridge│ │       │ │ (Qwen/Grok/...) │ │
+ │ └─────────────────────┘ │       │ └──────────────────┘ │
+ │  CEP/BatchPlay Layer     │       │   Queue + Storage     │
+ └─────────┬───────────────┘       └──────────┬────────────┘
+           │                                   │
+           ▼                                   ▼
+    Local Tensor Adapter (optional)     Cloud Model Providers
+```
+- **Front-End (UXP)**: Built with React Spectrum for consistent UI inside Photoshop.
+- **Bridge Layer**: Uses `photoshop.action.batchPlay` to interact with layers, selections, and history states.
+- **AI Orchestration API**: Node.js/Express (or Serverless) service that routes requests to selected AI providers, handles authentication, caching, and rate limiting.
+- **Optional Local Adapter**: When users install on high-end hardware, leverage ONNX Runtime or TensorRT for smaller finetuned checkpoints to minimize latency.
+
+## 5. Plugin Modules
+1. **Prompt Studio**
+   - Prompt templates by genre (portrait, product, landscape).
+   - Inline variable chips (e.g., `{lighting}`, `{camera}`) with tooltips.
+   - Negative prompts, seed control, CFG sliders (exposed when provider supports them).
+2. **Canvas Assist**
+   - Selection-aware editing (uses Photoshop selections as masks when sending edits).
+   - Preview panel with before/after toggles and blend slider.
+3. **Asset Manager**
+   - Browse generated images, tag favorites, and drag-drop onto canvas.
+   - Sync metadata (prompt, model, seed) via sidecar JSON stored in user workspace.
+4. **Model Switcher**
+   - Capability matrix (e.g., `Supports Inpainting`, `Max Resolution`).
+   - Provider-specific settings fetched from Orchestration API.
+5. **Collaboration & History**
+   - Stores AI session history in Photoshop `cloudDocuments` or local storage.
+   - Export shareable prompt recipes (.psai file) for teams.
+
+## 6. AI Backend Strategy
+- **Provider Abstraction**: Standardize requests as `Generate`, `Edit`, `Variate`, `Utility`. Map to provider endpoints using adapters.
+- **Authentication**: OAuth 2.0 (Meta AI, Google) and API keys (Qwen, Grok). Store encrypted tokens in Adobe secure storage (`storage.localFileSystem.secureStorage`).
+- **Content Safety**: Run prompts through moderation layer (e.g., Google Text Moderation API) before dispatch.
+- **Latency Optimization**: Use asynchronous job polling for slower providers; stream partial results (Server-Sent Events) to show progressive previews.
+
+## 7. Data Flow (Example: Inpainting)
+1. User makes a lasso selection in Photoshop.
+2. Plugin captures selection mask via `batchPlay` and exports the region as PNG.
+3. Front-end sends prompt, mask, and image data to Orchestration API.
+4. API chooses provider (e.g., Google Nano Banana) based on capability & quota.
+5. Provider returns edited image.
+6. Plugin inserts result as new layer, clipped to original selection, preserving history state for undo.
+
+## 8. UI/UX Guidelines
+- Use Adobe design language: dark theme, panels, accordions.
+- Provide undo-friendly operations (wrap modifications in `batchPlay` transactions).
+- Offer quick actions on Photoshop contextual taskbar when selection exists.
+- Include accessibility: keyboard navigation, screen-reader labels.
+
+## 9. Implementation Plan
+1. **Week 1–2: Foundations**
+   - Scaffold UXP plugin (`uxp plugin create`).
+   - Configure TypeScript, React, Redux Toolkit for state.
+   - Implement authentication manager and secure storage.
+2. **Week 3–4: Core Features**
+   - Build Prompt Studio UI and call Orchestration API.
+   - Implement layer export/import utilities.
+   - Integrate first provider (Qwen) with text-to-image.
+3. **Week 5–6: Advanced Editing**
+   - Add inpainting/outpainting workflows.
+   - Support asynchronous job handling and progress notifications.
+4. **Week 7–8: Multi-Provider & QA**
+   - Add Grok, Google Nano Banana, Meta adapters.
+   - Implement capability-based routing and fallback strategies.
+   - Conduct usability tests, performance tuning, finalize docs.
+
+## 10. Sample Code Fragments
+### 10.1 Fetch AI Result from Plugin
+```typescript
+import { batchPlay } from "photoshop";
+import { requestAI } from "./services/api";
+
+export async function generateLayerFromPrompt(prompt: string) {
+  const { documentID } = await app.activeDocument;
+  const exportResult = await batchPlay([
+    {
+      _obj: "copyToLayer",
+      _target: [{ _ref: "layer", _enum: "ordinal", _value: "targetEnum" }],
+    },
+    {
+      _obj: "save",
+      as: { _obj: "PNGFormat" },
+      in: { _path: "temp://selection.png" },
+      _options: { embedICCProfile: true },
+    },
+  ], { synchronousExecution: true });
+
+  const response = await requestAI({
+    model: "qwen-vl-plus",
+    operation: "generate",
+    prompt,
+    baseImagePath: exportResult[1].path,
+  });
+
+  await batchPlay([
+    {
+      _obj: "placedLayerMake",
+      target: response.assetPath,
+      documentID,
+    },
+  ], { synchronousExecution: true });
+}
+```
+
+### 10.2 Orchestration API Adapter Skeleton
+```typescript
+// server/adapters/qwen.ts
+import axios from "axios";
+import { AIJobRequest } from "../types";
+
+export async function callQwen(request: AIJobRequest) {
+  const { prompt, operation, baseImage } = request;
+  const payload = {
+    prompt,
+    image: baseImage,
+    size: request.size ?? "1024x1024",
+    negative_prompt: request.negativePrompt,
+  };
+
+  const { data } = await axios.post(
+    "https://api.qwen.cloud/v1/generate",
+    payload,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.QWEN_API_KEY}`,
+      },
+    }
+  );
+
+  return {
+    assetUrl: data.result.url,
+    metadata: data.result.metadata,
+  };
+}
+```
+
+## 11. Security & Compliance
+- Secure API credentials with Adobe UXP secure storage and encrypted server vaults (AWS Secrets Manager or GCP Secret Manager).
+- Support enterprise tenant isolation; route traffic through dedicated API keys per organization.
+- Log prompt/image usage with opt-in analytics, anonymized and compliant with GDPR/CCPA.
+- Provide content filters and manual review workflows for sensitive domains.
+
+## 12. Deployment & Distribution
+- Package plugin with `uxp pack` for Beta distribution via Adobe Exchange private listing.
+- Host Orchestration API on scalable infrastructure (e.g., Cloud Run, AWS Lambda + API Gateway).
+- Provide fallback for offline usage: limited local models and cached prompts.
+- Document onboarding with SSO, quotas, and pricing (per-request or subscription).
+
+## 13. Future Enhancements
+- **Real-time Co-Pilot**: Use streaming tokens for live brush suggestions.
+- **3D Asset Support**: Extend to PSD to GLTF conversions using Grok's multimodal capabilities.
+- **Team Prompt Library**: Cloud-hosted repository of curated prompts with rating system.
+- **Custom Model Fine-Tuning**: Allow enterprise customers to upload datasets and spin up dedicated endpoints.
+
+---
+*This document provides a blueprint for engineers and designers to begin implementing a robust AI-powered Photoshop plugin integrating multiple cutting-edge models.*


### PR DESCRIPTION
## Summary
- replace the placeholder README with a description of the Photoshop AI plugin concept repository
- add a comprehensive design document outlining architecture, workflows, and implementation guidance for a Photoshop 24.4 AI co-creation plugin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e282e2c62c832abe5c8cc2ddc40024