### PR TITLE
Add UXP panel prototype for Photoshop AI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# adobe_PS_AI-plugin
+# Adobe Photoshop AI Plugin Concepts
+
+This repository contains conceptual design work and a runnable prototype panel for integrating advanced generative or editing AI services into Adobe Photoshop 24.4 via UXP plugins. See [`docs/ai_plugin_design.md`](docs/ai_plugin_design.md) for the full architecture proposal and feature breakdown.
+
+## Repository Contents
+- `docs/ai_plugin_design.md` – comprehensive design for a hybrid cloud/on-device AI assistant plugin.
+- `uxp-plugin/` – unpackaged Photoshop UXP panel that demonstrates AI workflow orchestration, Photoshop API calls, and Spectrum Web Components styling.
+
+## Load the UXP Plugin Prototype
+1. Clone or download this repository.
+2. In Photoshop 24.4 (or newer), open **Plugins → Development → Load UXP Plugin…**
+3. Select the `uxp-plugin` directory. Photoshop will load the unpacked plugin immediately and open the **AI Co-Creation** panel.
+
+### What the panel demonstrates
+- Spectrum Web Components UI for configuring prompts, selecting AI backends (Qwen, Google Nano Banana, xAI Grok, Meta AI), and toggling workflow options.
+- Live document introspection through the Photoshop `app` module and `action.batchPlay`, surfaced as status text within the panel.
+- Placeholder AI preview generation rendered as SVG inside the panel for rapid iteration before wiring a real model endpoint.
+- A safe placeholder `core.executeAsModal` action that inserts a new layer in the active document, illustrating how to hand off AI output to Photoshop.
+
+### Connecting a real AI service
+- Replace the `simulatePreview` function in [`uxp-plugin/main.js`](uxp-plugin/main.js) with calls to your AI service endpoint (e.g., Qwen, Grok, Google "Nano Banana," or Meta AI).
+- Swap the placeholder layer creation logic with pixel import or smart object replacement once you have actual image bytes.
+- Extend [`uxp-plugin/manifest.json`](uxp-plugin/manifest.json) with additional commands or menu entries as needed.
+
+Refer back to [`docs/ai_plugin_design.md`](docs/ai_plugin_design.md) for environment setup, backend integration considerations, and security best practices.

--- a/docs/ai_plugin_design.md
+++ b/docs/ai_plugin_design.md
@@ -1,0 +1,184 @@
+# Photoshop 24.4 AI Co-Creation Plugin Design
+
+## 1. Vision & Value Proposition
+Create a UXP-based Photoshop 24.4 plugin that embeds state-of-the-art image generation and editing AI models (e.g., Alibaba Qwen, Google "Nano Banana," xAI Grok, Meta AI) directly into artist workflows. The plugin should:
+- Offer guided prompt crafting, iterative refinement, and contextual editing inside Photoshop.
+- Provide a unified interface for multiple AI backends while abstracting their differences.
+- Maintain user control by blending AI outputs with Photoshop layers and non-destructive editing tools.
+
+## 2. Primary Use Cases
+1. **Text-to-Image Generation** – Generate concept art or mood boards from prompts using models such as Qwen or Meta's Imagine.
+2. **Image-to-Image Variation** – Submit the current canvas or selected layers to Grok's diffusion service to explore styles.
+3. **Smart Inpainting/Outpainting** – Use Google Nano Banana's localized editing capabilities to remove or extend elements.
+4. **Style Transfer & Harmonization** – Apply model-specific filters to match a target reference image.
+5. **Assistive Automation** – Auto-mask subjects, relight scenes, and propose design variations with AI suggestions.
+
+## 3. User Personas
+- **Concept Artist**: Rapid prototyping of scenes and characters.
+- **Marketing Designer**: Variations for campaigns while adhering to brand guidelines.
+- **Retoucher**: Precision edits, background cleanup, and content-aware fill.
+
+## 4. High-Level Architecture
+```
+ ┌─────────────────────────┐       ┌──────────────────────┐
+ │ Photoshop 24.4 (UXP)    │       │ AI Orchestration API │
+ │ ┌─────────────────────┐ │ HTTPS │ ┌──────────────────┐ │
+ │ │ Plugin UI (React)   │◄───────┼─►│ Model Routers   │ │
+ │ │ Photoshop DOM Bridge│ │       │ │ (Qwen/Grok/...) │ │
+ │ └─────────────────────┘ │       │ └──────────────────┘ │
+ │  CEP/BatchPlay Layer     │       │   Queue + Storage     │
+ └─────────┬───────────────┘       └──────────┬────────────┘
+           │                                   │
+           ▼                                   ▼
+    Local Tensor Adapter (optional)     Cloud Model Providers
+```
+- **Front-End (UXP)**: Built with React Spectrum for consistent UI inside Photoshop.
+- **Bridge Layer**: Uses `photoshop.action.batchPlay` to interact with layers, selections, and history states.
+- **AI Orchestration API**: Node.js/Express (or Serverless) service that routes requests to selected AI providers, handles authentication, caching, and rate limiting.
+- **Optional Local Adapter**: When users install on high-end hardware, leverage ONNX Runtime or TensorRT for smaller finetuned checkpoints to minimize latency.
+
+## 5. Plugin Modules
+1. **Prompt Studio**
+   - Prompt templates by genre (portrait, product, landscape).
+   - Inline variable chips (e.g., `{lighting}`, `{camera}`) with tooltips.
+   - Negative prompts, seed control, CFG sliders (exposed when provider supports them).
+2. **Canvas Assist**
+   - Selection-aware editing (uses Photoshop selections as masks when sending edits).
+   - Preview panel with before/after toggles and blend slider.
+3. **Asset Manager**
+   - Browse generated images, tag favorites, and drag-drop onto canvas.
+   - Sync metadata (prompt, model, seed) via sidecar JSON stored in user workspace.
+4. **Model Switcher**
+   - Capability matrix (e.g., `Supports Inpainting`, `Max Resolution`).
+   - Provider-specific settings fetched from Orchestration API.
+5. **Collaboration & History**
+   - Stores AI session history in Photoshop `cloudDocuments` or local storage.
+   - Export shareable prompt recipes (.psai file) for teams.
+
+## 6. AI Backend Strategy
+- **Provider Abstraction**: Standardize requests as `Generate`, `Edit`, `Variate`, `Utility`. Map to provider endpoints using adapters.
+- **Authentication**: OAuth 2.0 (Meta AI, Google) and API keys (Qwen, Grok). Store encrypted tokens in Adobe secure storage (`storage.localFileSystem.secureStorage`).
+- **Content Safety**: Run prompts through moderation layer (e.g., Google Text Moderation API) before dispatch.
+- **Latency Optimization**: Use asynchronous job polling for slower providers; stream partial results (Server-Sent Events) to show progressive previews.
+
+## 7. Data Flow (Example: Inpainting)
+1. User makes a lasso selection in Photoshop.
+2. Plugin captures selection mask via `batchPlay` and exports the region as PNG.
+3. Front-end sends prompt, mask, and image data to Orchestration API.
+4. API chooses provider (e.g., Google Nano Banana) based on capability & quota.
+5. Provider returns edited image.
+6. Plugin inserts result as new layer, clipped to original selection, preserving history state for undo.
+
+## 8. UI/UX Guidelines
+- Use Adobe design language: dark theme, panels, accordions.
+- Provide undo-friendly operations (wrap modifications in `batchPlay` transactions).
+- Offer quick actions on Photoshop contextual taskbar when selection exists.
+- Include accessibility: keyboard navigation, screen-reader labels.
+
+## 9. Implementation Plan
+1. **Week 1–2: Foundations**
+   - Scaffold UXP plugin (`uxp plugin create`).
+   - Configure TypeScript, React, Redux Toolkit for state.
+   - Implement authentication manager and secure storage.
+2. **Week 3–4: Core Features**
+   - Build Prompt Studio UI and call Orchestration API.
+   - Implement layer export/import utilities.
+   - Integrate first provider (Qwen) with text-to-image.
+3. **Week 5–6: Advanced Editing**
+   - Add inpainting/outpainting workflows.
+   - Support asynchronous job handling and progress notifications.
+4. **Week 7–8: Multi-Provider & QA**
+   - Add Grok, Google Nano Banana, Meta adapters.
+   - Implement capability-based routing and fallback strategies.
+   - Conduct usability tests, performance tuning, finalize docs.
+
+## 10. Sample Code Fragments
+### 10.1 Fetch AI Result from Plugin
+```typescript
+import { batchPlay } from "photoshop";
+import { requestAI } from "./services/api";
+
+export async function generateLayerFromPrompt(prompt: string) {
+  const { documentID } = await app.activeDocument;
+  const exportResult = await batchPlay([
+    {
+      _obj: "copyToLayer",
+      _target: [{ _ref: "layer", _enum: "ordinal", _value: "targetEnum" }],
+    },
+    {
+      _obj: "save",
+      as: { _obj: "PNGFormat" },
+      in: { _path: "temp://selection.png" },
+      _options: { embedICCProfile: true },
+    },
+  ], { synchronousExecution: true });
+
+  const response = await requestAI({
+    model: "qwen-vl-plus",
+    operation: "generate",
+    prompt,
+    baseImagePath: exportResult[1].path,
+  });
+
+  await batchPlay([
+    {
+      _obj: "placedLayerMake",
+      target: response.assetPath,
+      documentID,
+    },
+  ], { synchronousExecution: true });
+}
+```
+
+### 10.2 Orchestration API Adapter Skeleton
+```typescript
+// server/adapters/qwen.ts
+import axios from "axios";
+import { AIJobRequest } from "../types";
+
+export async function callQwen(request: AIJobRequest) {
+  const { prompt, operation, baseImage } = request;
+  const payload = {
+    prompt,
+    image: baseImage,
+    size: request.size ?? "1024x1024",
+    negative_prompt: request.negativePrompt,
+  };
+
+  const { data } = await axios.post(
+    "https://api.qwen.cloud/v1/generate",
+    payload,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.QWEN_API_KEY}`,
+      },
+    }
+  );
+
+  return {
+    assetUrl: data.result.url,
+    metadata: data.result.metadata,
+  };
+}
+```
+
+## 11. Security & Compliance
+- Secure API credentials with Adobe UXP secure storage and encrypted server vaults (AWS Secrets Manager or GCP Secret Manager).
+- Support enterprise tenant isolation; route traffic through dedicated API keys per organization.
+- Log prompt/image usage with opt-in analytics, anonymized and compliant with GDPR/CCPA.
+- Provide content filters and manual review workflows for sensitive domains.
+
+## 12. Deployment & Distribution
+- Package plugin with `uxp pack` for Beta distribution via Adobe Exchange private listing.
+- Host Orchestration API on scalable infrastructure (e.g., Cloud Run, AWS Lambda + API Gateway).
+- Provide fallback for offline usage: limited local models and cached prompts.
+- Document onboarding with SSO, quotas, and pricing (per-request or subscription).
+
+## 13. Future Enhancements
+- **Real-time Co-Pilot**: Use streaming tokens for live brush suggestions.
+- **3D Asset Support**: Extend to PSD to GLTF conversions using Grok's multimodal capabilities.
+- **Team Prompt Library**: Cloud-hosted repository of curated prompts with rating system.
+- **Custom Model Fine-Tuning**: Allow enterprise customers to upload datasets and spin up dedicated endpoints.
+
+---
+*This document provides a blueprint for engineers and designers to begin implementing a robust AI-powered Photoshop plugin integrating multiple cutting-edge models.*

--- a/uxp-plugin/index.html
+++ b/uxp-plugin/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>AI Co-Creation Studio</title>
+    <link rel="stylesheet" href="https://unpkg.com/@spectrum-web-components/styles/dist/themes/light.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@spectrum-web-components/styles/dist/scale-medium.css" />
+    <link rel="stylesheet" href="styles.css" />
+    <script type="module" src="https://unpkg.com/@spectrum-web-components/bundle/elements.js"></script>
+    <script type="module" src="main.js"></script>
+  </head>
+  <body>
+    <sp-theme scale="medium" color="light" class="panel-shell">
+      <sp-heading size="L" class="panel-title">AI Co-Creation Studio</sp-heading>
+      <sp-body size="S" class="subtitle">
+        Blend Qwen, Grok, Google Nano Banana, or Meta AI models into Photoshop 24.4 workflows.
+      </sp-body>
+
+      <section class="group">
+        <sp-field-label for="model-picker">Model</sp-field-label>
+        <sp-picker id="model-picker" placeholder="Select a model" value="qwen">
+          <sp-menu>
+            <sp-menu-item value="qwen">Qwen (Alibaba)</sp-menu-item>
+            <sp-menu-item value="nano-banana">Google Nano Banana</sp-menu-item>
+            <sp-menu-item value="grok">xAI Grok</sp-menu-item>
+            <sp-menu-item value="meta">Meta AI</sp-menu-item>
+          </sp-menu>
+        </sp-picker>
+      </section>
+
+      <section class="group">
+        <sp-field-label for="workflow-picker">Workflow</sp-field-label>
+        <sp-picker id="workflow-picker" placeholder="Select a workflow" value="generate">
+          <sp-menu>
+            <sp-menu-item value="generate">Generate new artwork</sp-menu-item>
+            <sp-menu-item value="edit">Edit current selection</sp-menu-item>
+            <sp-menu-item value="expand">Outpaint beyond canvas</sp-menu-item>
+          </sp-menu>
+        </sp-picker>
+      </section>
+
+      <section class="group">
+        <sp-field-label for="prompt-input">Prompt</sp-field-label>
+        <sp-textarea
+          id="prompt-input"
+          placeholder="Describe what you would like to create or modify..."
+          maxlength="500"
+        ></sp-textarea>
+      </section>
+
+      <section class="group row slider-row">
+        <sp-field-label for="strength-slider">Variation strength</sp-field-label>
+        <sp-slider id="strength-slider" min="0" max="100" value="35" variant="tick"></sp-slider>
+        <sp-body size="S" id="strength-value">35%</sp-body>
+      </section>
+
+      <section class="group row">
+        <sp-switch id="seamless-switch" checked>Preserve subject fidelity</sp-switch>
+        <sp-switch id="mask-switch">Respect active mask</sp-switch>
+      </section>
+
+      <section class="group row actions">
+        <sp-button id="refresh-button" variant="secondary">Refresh document info</sp-button>
+        <sp-button id="generate-button" variant="cta">Generate preview</sp-button>
+        <sp-button id="apply-button" variant="accent" disabled>Apply to Photoshop</sp-button>
+      </section>
+
+      <section class="group">
+        <sp-heading size="XS">Preview</sp-heading>
+        <div id="preview-surface">
+          <img id="preview-image" alt="AI preview" hidden />
+          <div id="preview-placeholder">Preview output will appear here.</div>
+        </div>
+      </section>
+
+      <section class="group">
+        <sp-detail size="S" id="status-text">Ready.</sp-detail>
+        <sp-progress-bar id="progress" indeterminate hidden>Processing</sp-progress-bar>
+      </section>
+
+      <section class="group">
+        <sp-heading size="XS">Active document</sp-heading>
+        <sp-body size="S" id="document-info">No Photoshop document detected.</sp-body>
+      </section>
+    </sp-theme>
+  </body>
+</html>

--- a/uxp-plugin/main.js
+++ b/uxp-plugin/main.js
@@ -1,0 +1,265 @@
+import { app, core, action } from "photoshop";
+
+const MODEL_LABELS = {
+  qwen: "Qwen (Alibaba)",
+  "nano-banana": "Google Nano Banana",
+  grok: "xAI Grok",
+  meta: "Meta AI"
+};
+
+const WORKFLOW_LABELS = {
+  generate: "Generate new artwork",
+  edit: "Edit current selection",
+  expand: "Outpaint beyond canvas"
+};
+
+const state = {
+  preview: null
+};
+
+function init() {
+  const elements = {
+    promptInput: document.getElementById("prompt-input"),
+    modelPicker: document.getElementById("model-picker"),
+    workflowPicker: document.getElementById("workflow-picker"),
+    strengthSlider: document.getElementById("strength-slider"),
+    strengthValue: document.getElementById("strength-value"),
+    seamlessSwitch: document.getElementById("seamless-switch"),
+    maskSwitch: document.getElementById("mask-switch"),
+    generateButton: document.getElementById("generate-button"),
+    applyButton: document.getElementById("apply-button"),
+    refreshButton: document.getElementById("refresh-button"),
+    statusText: document.getElementById("status-text"),
+    progressBar: document.getElementById("progress"),
+    previewImage: document.getElementById("preview-image"),
+    previewPlaceholder: document.getElementById("preview-placeholder"),
+    documentInfo: document.getElementById("document-info")
+  };
+
+  elements.strengthSlider.addEventListener("input", (event) => {
+    elements.strengthValue.textContent = `${event.target.value}%`;
+  });
+
+  elements.generateButton.addEventListener("click", async () => {
+    await handleGenerate(elements);
+  });
+
+  elements.applyButton.addEventListener("click", async () => {
+    await handleApply(elements);
+  });
+
+  elements.refreshButton.addEventListener("click", async () => {
+    await updateDocumentInfo(elements);
+  });
+
+  updateDocumentInfo(elements).catch((error) => {
+    console.error("Failed to load document info on init", error);
+  });
+}
+
+async function handleGenerate(elements) {
+  const prompt = elements.promptInput.value.trim();
+  if (!prompt) {
+    setStatus(elements, "warning", "Please enter a prompt before generating a preview.");
+    return;
+  }
+
+  setProcessing(elements, true);
+  setStatus(elements, "pending", "Contacting AI service...");
+  elements.previewPlaceholder.hidden = false;
+  elements.previewPlaceholder.textContent = "Generating preview...";
+  elements.previewImage.hidden = true;
+
+  try {
+    const [documentSummary, previewUrl] = await Promise.all([
+      fetchDocumentSummary(),
+      simulatePreview(elements, prompt)
+    ]);
+
+    state.preview = {
+      url: previewUrl,
+      prompt,
+      model: elements.modelPicker.value,
+      workflow: elements.workflowPicker.value,
+      strength: Number(elements.strengthSlider.value),
+      preserveSubject: elements.seamlessSwitch.checked,
+      respectMask: elements.maskSwitch.checked,
+      documentSummary
+    };
+
+    elements.previewImage.src = state.preview.url;
+    elements.previewImage.hidden = false;
+    elements.previewPlaceholder.hidden = true;
+
+    elements.applyButton.disabled = false;
+
+    setStatus(elements, "success", "Preview generated. Apply to Photoshop to insert a placeholder layer.");
+  } catch (error) {
+    console.error("Preview generation failed", error);
+    setStatus(elements, "error", `Preview failed: ${error.message}`);
+  } finally {
+    setProcessing(elements, false);
+  }
+}
+
+async function handleApply(elements) {
+  if (!state.preview) {
+    setStatus(elements, "warning", "Generate a preview before applying.");
+    return;
+  }
+
+  if (!app.documents.length) {
+    setStatus(elements, "warning", "Open a Photoshop document to apply the AI result.");
+    return;
+  }
+
+  setProcessing(elements, true);
+  setStatus(elements, "pending", "Creating Photoshop layer placeholder...");
+
+  try {
+    await core.executeAsModal(async () => {
+      const document = app.activeDocument;
+      const layerName = `${MODEL_LABELS[state.preview.model] || "AI"} • ${state.preview.workflow}`;
+      await document.createLayer({ name: layerName });
+    }, { commandName: "AI Placeholder Layer" });
+
+    setStatus(elements, "success", "Placeholder layer created. Replace its contents with the generated pixels from your service.");
+  } catch (error) {
+    console.error("Failed to create placeholder layer", error);
+    setStatus(elements, "error", `Could not apply result: ${error.message}`);
+  } finally {
+    setProcessing(elements, false);
+    await updateDocumentInfo(elements);
+  }
+}
+
+async function updateDocumentInfo(elements) {
+  try {
+    const summary = await fetchDocumentSummary();
+    elements.documentInfo.textContent = summary
+      ? formatDocumentSummary(summary)
+      : "No Photoshop document detected.";
+  } catch (error) {
+    console.error("Failed to fetch document info", error);
+    elements.documentInfo.textContent = `Error loading document info: ${error.message}`;
+  }
+}
+
+async function fetchDocumentSummary() {
+  if (!app.documents.length) {
+    return null;
+  }
+
+  const document = app.activeDocument;
+  const docSummary = {
+    name: document.title || document.name || "Untitled",
+    widthPx: undefined,
+    heightPx: undefined,
+    resolution: document.resolution,
+    numberOfLayers: undefined
+  };
+
+  if (document.width && typeof document.width.as === "function") {
+    docSummary.widthPx = Number(document.width.as("px"));
+  }
+  if (document.height && typeof document.height.as === "function") {
+    docSummary.heightPx = Number(document.height.as("px"));
+  }
+
+  try {
+    const [descriptor] = await action.batchPlay([
+      {
+        _obj: "get",
+        _target: [
+          {
+            _ref: "document",
+            _enum: "ordinal",
+            _value: "targetEnum"
+          }
+        ]
+      }
+    ], {
+      synchronousExecution: true,
+      modalBehavior: "execute"
+    });
+
+    if (descriptor && typeof descriptor.numberOfLayers === "number") {
+      docSummary.numberOfLayers = descriptor.numberOfLayers;
+    }
+  } catch (error) {
+    console.warn("batchPlay document descriptor failed", error);
+  }
+
+  return docSummary;
+}
+
+function simulatePreview(elements, prompt) {
+  const modelLabel = MODEL_LABELS[elements.modelPicker.value] || "Custom model";
+  const workflowLabel = WORKFLOW_LABELS[elements.workflowPicker.value] || "Workflow";
+  const strength = Number(elements.strengthSlider.value);
+  const preserveSubject = elements.seamlessSwitch.checked ? "Yes" : "No";
+  const respectMask = elements.maskSwitch.checked ? "Yes" : "No";
+
+  const documentSummary = elements.documentInfo.textContent;
+  const text = `Model: ${modelLabel}\nWorkflow: ${workflowLabel}\nStrength: ${strength}%\nPreserve Subject: ${preserveSubject}\nRespect Mask: ${respectMask}\nPrompt: ${prompt}\n${documentSummary}`;
+
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'>
+    <defs>
+      <linearGradient id='bg' x1='0%' y1='0%' x2='100%' y2='100%'>
+        <stop offset='0%' stop-color='#1473E6'/>
+        <stop offset='100%' stop-color='#5C6BC0'/>
+      </linearGradient>
+    </defs>
+    <rect width='800' height='600' rx='32' fill='url(#bg)' />
+    <foreignObject x='32' y='32' width='736' height='536'>
+      <body xmlns='http://www.w3.org/1999/xhtml' style='color:white;font-family:Arial,Helvetica,sans-serif;'>
+        <h2 style='margin:0 0 12px 0;'>AI Preview</h2>
+        <pre style='white-space:pre-wrap;font-size:20px;line-height:1.4;'>${escapeHtml(text)}</pre>
+      </body>
+    </foreignObject>
+  </svg>`;
+
+  const encoded = encodeURIComponent(svg).replace(/'/g, "%27").replace(/\(/g, "%28").replace(/\)/g, "%29");
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(`data:image/svg+xml,${encoded}`);
+    }, 500);
+  });
+}
+
+function formatDocumentSummary(summary) {
+  const width = summary.widthPx ? `${Math.round(summary.widthPx)} px` : "Unknown width";
+  const height = summary.heightPx ? `${Math.round(summary.heightPx)} px` : "Unknown height";
+  const layers = summary.numberOfLayers != null ? `${summary.numberOfLayers} layers` : "Layer count unavailable";
+  const resolution = summary.resolution ? `${summary.resolution} ppi` : "Resolution unknown";
+
+  return `${summary.name}\n${width} × ${height}\n${layers}\n${resolution}`;
+}
+
+function setStatus(elements, status, message) {
+  elements.statusText.textContent = message;
+  elements.statusText.dataset.status = status;
+}
+
+function setProcessing(elements, isProcessing) {
+  elements.generateButton.disabled = isProcessing;
+  elements.refreshButton.disabled = isProcessing;
+  elements.progressBar.hidden = !isProcessing;
+  elements.applyButton.disabled = isProcessing || !state.preview;
+  if (!state.preview) {
+    elements.previewPlaceholder.hidden = false;
+    elements.previewImage.hidden = true;
+  }
+}
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+window.addEventListener("DOMContentLoaded", init);

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "com.adobe.ai.cocreation.prototype",
+  "name": "AI Co-Creation Studio",
+  "version": "0.1.0",
+  "description": "Prototype Photoshop 24.4 panel that orchestrates AI-assisted generation and editing workflows.",
+  "manifestVersion": 5,
+  "host": [
+    {
+      "app": "PS",
+      "minVersion": "24.4.0"
+    }
+  ],
+  "entrypoints": [
+    {
+      "type": "panel",
+      "id": "aiCoCreationPanel",
+      "label": "AI Co-Creation",
+      "panel": {
+        "mainPath": "index.html",
+        "preferredDockingTypes": [
+          "panel"
+        ]
+      }
+    }
+  ]
+}

--- a/uxp-plugin/styles.css
+++ b/uxp-plugin/styles.css
@@ -1,0 +1,100 @@
+body {
+  margin: 0;
+  font-family: var(--spectrum-font-family-base);
+}
+
+.panel-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  width: 320px;
+  box-sizing: border-box;
+}
+
+.panel-title {
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--spectrum-global-color-gray-600);
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.group.row {
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+}
+
+.slider-row {
+  align-items: flex-end;
+}
+
+#strength-value {
+  width: 48px;
+  text-align: right;
+}
+
+.actions sp-button {
+  flex: 1;
+}
+
+#prompt-input {
+  min-height: 90px;
+}
+
+#preview-surface {
+  border: 1px solid var(--spectrum-global-color-gray-300);
+  border-radius: 6px;
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--spectrum-global-color-gray-75);
+  position: relative;
+  overflow: hidden;
+}
+
+#preview-surface img {
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+}
+
+#preview-placeholder {
+  text-align: center;
+  padding: 16px;
+  color: var(--spectrum-global-color-gray-600);
+}
+
+#status-text[data-status="error"] {
+  color: var(--spectrum-global-color-red-600);
+}
+
+#status-text[data-status="warning"] {
+  color: var(--spectrum-global-color-orange-500);
+}
+
+#status-text[data-status="success"] {
+  color: var(--spectrum-global-color-green-600);
+}
+
+#progress[hidden] {
+  display: none;
+}
+
+#preview-image[hidden] {
+  display: none;
+}
+
+#document-info {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- add an unpacked Photoshop 24.4 UXP panel prototype styled with Spectrum Web Components for configuring AI models and workflows
- implement placeholder preview rendering plus Photoshop `app` and `action.batchPlay` integrations, including a modal layer creation example
- document how to load the plugin in development mode and extend it to call real AI services

## Testing
- not run (Photoshop-dependent plugin)


------
https://chatgpt.com/codex/tasks/task_e_68e282e2c62c832abe5c8cc2ddc40024